### PR TITLE
Add support for standard Rednet repeaters

### DIFF
--- a/TAFiles/APIs/rednet.lua
+++ b/TAFiles/APIs/rednet.lua
@@ -5,6 +5,10 @@ rednet = setmetatable(
       content.rID = type(rID) == "table" and rID or {[rID] = true}
       content.sID = os.id
       content.event = event
+      -- Fields used by repeaters
+      content.nMessageID = math.random( 1, 2147483647 )
+      content.nRecipient = modemChannel
+      -- End Fields used by repeaters
       local clear
       for id in pairs(content.rID) do
         local timerId
@@ -46,6 +50,11 @@ rednet = setmetatable(
       end
       modem.transmit(
         modemChannel,
+        modemChannel,
+        content
+      )
+      modem.transmit( -- Also transmit on the repeater channel
+        65533,
         modemChannel,
         content
       )

--- a/TAFiles/EventHandlers/common.Lua
+++ b/TAFiles/EventHandlers/common.Lua
@@ -1,3 +1,7 @@
+-- Variables used for the modem_message handler
+local modem_messageMessages = {}
+local modem_messageTimeouts = {}
+
 local common
 common = { --common event handlers, these are always active
   turtle_response = function(tEvent)
@@ -63,6 +67,10 @@ common = { --common event handlers, these are always active
     elseif os.sleepTimer[timerID] then
       os.sleepTimer[timerID]()
       return true
+    elseif modem_messageTimeouts[timerID] then
+      local messageID = modem_messageTimeouts[ timerID ]
+      modem_messageTimeouts[ timerID ] = nil
+      modem_messageMessages[ messageID ] = nil
     end
   end,
   peripheral = function(tEvent)
@@ -244,6 +252,15 @@ common = { --common event handlers, these are always active
       local event = data.event
       local senderId = data.sID
       local type = data.type
+      if data.nMessageID ~= nil then
+        if modem_messageMessages[ data.nMessageID ] then
+          -- The message is a duplicate
+          return true
+        else
+          modem_messageMessages[ data.nMessageID ] = true
+          modem_messageTimeouts[ os.startTimer( 30 ) ] = data.nMessageID
+        end
+      end
       if event == "Success" then
         local func = tTransmissions.success[type][senderId]
         if func then


### PR DESCRIPTION
To enable TA's use on large projects in CC 1.75 (the last version for MC 1.7.10, before ender modems were added), I have made some changes to the networking code.

Messages sent with this version include two additional fields, which are required by the standard "repeat" script. Additionally, this version checks for duplicate messages and discards them.

When no repeaters are present, these changes should be 100% backwards compatible. When repeaters are present, old versions of TA may receive the same message multiple times. I have not tested the effect of duplicate messages on TA, but presumably there would be issues if some sync'd turtles are updated and others are not.